### PR TITLE
Allow casting without input containing catch/finally.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,11 @@ module.exports.compile = function(source) {
   return code;
 };
 
-var TEST_REGEX = module.exports.TEST_REGEX = /catch|finally/i;
+var TEST_REGEX = module.exports.TEST_REGEX = buildTestRegex();
+function buildTestRegex() {
+  var regexString = Object.keys(identifierToLiteral).join('|');
+  return new RegExp(regexString, 'i');
+}
 
 module.exports.visit = function(ast) {
   new ES6Safe().visit(ast);

--- a/tests/compiler-test.js
+++ b/tests/compiler-test.js
@@ -23,3 +23,115 @@ describe('object member', function() {
     astEqual(actual, expected, 'expected input.js and output.js to match');
   });
 });
+
+describe('catch', function() {
+  it('works with literal syntax', function() {
+    var actual = compiler.compile('var object = {\ncatch: null,\n};');
+    var expected = 'var object = {\n"catch": null,\n};'
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+
+  it('works with member syntax', function() {
+    var actual = compiler.compile('object.catch(function(){\n\n});');
+    var expected = 'object["catch"](function(){\n\n});';
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+});
+
+describe('finally', function() {
+  it('works with literal syntax', function() {
+    var actual = compiler.compile('var object = {\nfinally: null,\n};');
+    var expected = 'var object = {\n"finally": null,\n};'
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+
+  it('works with member syntax', function() {
+    var actual = compiler.compile('object.finally(function(){\n\n});');
+    var expected = 'object["finally"](function(){\n\n});';
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+});
+
+describe('default', function() {
+  it('works with literal syntax', function() {
+    var actual = compiler.compile('var object = {\ndefault: null,\n};');
+    var expected = 'var object = {\n"default": null,\n};'
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+
+  it('works with member syntax', function() {
+    var actual = compiler.compile('object.default(function(){\n\n});');
+    var expected = 'object["default"](function(){\n\n});';
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+});
+
+describe('new', function() {
+  it('works with literal syntax', function() {
+    var actual = compiler.compile('var object = {\nnew: null,\n};');
+    var expected = 'var object = {\n"new": null,\n};'
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+
+  it('works with member syntax', function() {
+    var actual = compiler.compile('object.new(function(){\n\n});');
+    var expected = 'object["new"](function(){\n\n});';
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+});
+
+describe('throw', function() {
+  it('works with literal syntax', function() {
+    var actual = compiler.compile('var object = {\nthrow: null,\n};');
+    var expected = 'var object = {\n"throw": null,\n};'
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+
+  it('works with member syntax', function() {
+    var actual = compiler.compile('object.throw(function(){\n\n});');
+    var expected = 'object["throw"](function(){\n\n});';
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+});
+
+describe('return', function() {
+  it('works with literal syntax', function() {
+    var actual = compiler.compile('var object = {\nreturn: null,\n};');
+    var expected = 'var object = {\n"return": null,\n};'
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+
+  it('works with member syntax', function() {
+    var actual = compiler.compile('object.return(function(){\n\n});');
+    var expected = 'object["return"](function(){\n\n});';
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+});
+
+describe('import', function() {
+  it('works with literal syntax', function() {
+    var actual = compiler.compile('var object = {\nimport: null,\n};');
+    var expected = 'var object = {\n"import": null,\n};'
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+
+  it('works with member syntax', function() {
+    var actual = compiler.compile('object.import(function(){\n\n});');
+    var expected = 'object["import"](function(){\n\n});';
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
+  });
+});


### PR DESCRIPTION
The RegExp that was used as a quick check filter was only looking for `catch` and `finally`. This meant that it would not recast any of the other identifiers if `catch`/`finally` did not also exist in the input.

Changes:
- Added tests for the individual literals (in both object literal and object member formats).
- Build the RegExp dynamically based on the actual literals being matched. This could have been done inline, but I believe that we will likely have other scenarios to check, and will likely need to have the ability to construct more complicationed RegExps anyways.
