### PR TITLE
Update recast to 0.8.0.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-var esprima = require('esprima');
 var recast = require('recast');
 var Visitor = recast.Visitor;
 var types = recast.types;
@@ -103,7 +102,7 @@ var TEST_REGEX = module.exports.TEST_REGEX = buildTestRegex();
 module.exports.compile = function(source) {
   var ast, code;
   if (TEST_REGEX.test(source)) {
-    ast = recast.parse(source, { esprima: esprima } );
+    ast = recast.parse(source);
     new ES6Safe().visit(ast);
     code = recast.print(ast).code;
   } else {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
   "author": "Stefan Penner",
   "license": "ISC",
   "dependencies": {
-    "recast": "~0.5.20",
-    "es-simpler-traverser": "0.0.1",
-    "esprima": "git+https://github.com/thomasboyt/esprima#4be906f1abcbb"
+    "recast": "~0.8.0",
+    "es-simpler-traverser": "0.0.1"
   },
   "devDependencies": {
     "mocha": "~1.18.2",

--- a/tests/compiler-test.js
+++ b/tests/compiler-test.js
@@ -15,10 +15,12 @@ describe('object properties', function() {
 });
 
 describe('parses es6-module-syntax without error', function() {
-  it('works', function(done) {
+  it('works', function() {
     var path = './tests/fixtures/es6-module-syntax';
     var actual = compiler.compile(readFileSync(path + '/input.js'));
-    done();
+    var expected = readFileSync(path + '/output.js');
+
+    astEqual(actual, expected, 'expected input.js and output.js to match');
   });
 });
 

--- a/tests/fixtures/es6-module-syntax/input.js
+++ b/tests/fixtures/es6-module-syntax/input.js
@@ -1,6 +1,8 @@
 export default {
   name: 'foo',
   initializer: function(container, app) {
-
+    return {
+      default: 'something'
+    };
   }
 }


### PR DESCRIPTION
Removes custom esprima version (recast is using the commonly agreed upon esprima-fb package which is being kept up to date with the harmony changes upstream).
